### PR TITLE
Sync current BoxJs beta subscription

### DIFF
--- a/BiliBili.boxjs.beta.json
+++ b/BiliBili.boxjs.beta.json
@@ -1,15 +1,15 @@
 {
-	"id": "BiliUniverse.BiliBili.beta.sub",
-	"name": "🪐 BiliUniverse: 📺 BiliBili β",
-	"author": "@BiliUniverse",
+	"id": "Biliverse.BiliBili.beta.sub",
+	"name": "🪐 Biliverse: 📺 BiliBili β",
+	"author": "@Biliverse",
 	"description": "哔哩哔哩中国版流媒体平台功能增强系列",
 	"icon": "https://avatars.githubusercontent.com/u/129515498?s=200&v=4",
-	"repo": "https://github.com/BiliUniverse/Universe",
+	"repo": "https://github.com/Biliverse/Universe",
 	"apps": [
 		{
 			"id": "BiliBili.Enhanced.Home.beta",
 			"name": "📺 BiliBili: ⚙ Enhanced (首页) β",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Home", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -98,14 +98,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced/tree/dev",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Enhanced.Region.beta",
 			"name": "📺 BiliBili: ⚙ Enhanced (分区) β",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Region", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -326,14 +326,14 @@
 					"desc": "选择要显示的分区"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced/tree/dev",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Enhanced.Mine.beta",
 			"name": "📺 BiliBili: ⚙ Enhanced (我的) iOS版 β",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Mine", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -483,14 +483,14 @@
 					"desc": ""
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced/tree/dev",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Enhanced.Mine.iPad.beta",
 			"name": "📺 BiliBili: ⚙ Enhanced (我的) iPad版 β",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Mine.iPad", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -584,14 +584,14 @@
 					"desc": ""
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced/tree/dev",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Global.beta",
 			"name": "📺 BiliBili: 🌐 Global β",
-			"descs_html": ["使用说明请见<a href=\"https://Global.BiliUniverse.io\">🪐 BiliUniverse: 🌐 Global</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/global\">🪐 Biliverse: 🌐 Global</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Global.Settings", "@BiliBili.Global.Caches"],
 			"settings": [
 				{
@@ -623,14 +623,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Global/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Global/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Global/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Global/tree/dev",
+			"icons": ["https://github.com/Biliverse/Global/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Global/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Redirect.beta",
 			"name": "📺 BiliBili: 🔀 Redirect β",
-			"descs_html": ["使用说明请见<a href=\"https://Redirect.BiliUniverse.io\">🪐 BiliUniverse: 🔀 Redirect</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/redirect\">🪐 Biliverse: 🔀 Redirect</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Redirect.Settings", "@BiliBili.Redirect.Caches"],
 			"settings": [
 				{
@@ -688,14 +688,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Redirect/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Redirect/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Redirect/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Redirect/tree/dev",
+			"icons": ["https://github.com/Biliverse/Redirect/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Redirect/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.ADBlock.beta",
 			"name": "📺 BiliBili: 🛡️ ADBlock β",
-			"descs_html": ["使用说明请见<a href=\"https://ADBlock.BiliUniverse.io\">🪐 BiliUniverse: 🛡️ ADBlock</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/ad-block\">🪐 Biliverse: 🛡️ ADBlock</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.ADBlock.Settings", "@BiliBili.ADBlock.Caches"],
 			"settings": [
 				{ "id": "@BiliBili.ADBlock.Settings.Splash", "name": "[开屏] 去除广告", "type": "boolean", "val": true, "desc": "是否启用此处修改" },
@@ -724,14 +724,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/ADBlock/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/ADBlock/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/ADBlock/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/ADBlock/tree/dev",
+			"icons": ["https://github.com/Biliverse/ADBlock/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/ADBlock/raw/dev/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Roaming.beta",
 			"name": "📺 BiliBili: ✈ Roaming β",
-			"descs_html": ["使用说明请见<a href=\"https://Roaming.BiliUniverse.io\">🪐 BiliUniverse: ✈ Roaming</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/roaming\">🪐 Biliverse: ✈ Roaming</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Roaming.Settings", "@BiliBili.Roaming.Caches"],
 			"settings": [
 				{
@@ -835,9 +835,9 @@
 					"desc": "一行一个代理域名，以回车/换行分隔多个域名，留空不修改"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Roaming/tree/dev",
-			"icons": ["https://github.com/BiliUniverse/Roaming/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Roaming/raw/dev/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Roaming/tree/dev",
+			"icons": ["https://github.com/Biliverse/Roaming/raw/dev/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Roaming/raw/dev/src/assets/icon_circled_108x.png"]
 		}
 	]
 }

--- a/BiliBili.boxjs.json
+++ b/BiliBili.boxjs.json
@@ -1,15 +1,15 @@
 {
-	"id": "BiliUniverse.BiliBili.sub",
-	"name": "🪐 BiliUniverse: 📺 BiliBili",
-	"author": "@BiliUniverse",
+	"id": "Biliverse.BiliBili.sub",
+	"name": "🪐 Biliverse: 📺 BiliBili",
+	"author": "@Biliverse",
 	"description": "哔哩哔哩中国版流媒体平台功能增强系列",
 	"icon": "https://avatars.githubusercontent.com/u/129515498?s=200&v=4",
-	"repo": "https://github.com/BiliUniverse/Universe",
+	"repo": "https://github.com/Biliverse/Universe",
 	"apps": [
 		{
 			"id": "BiliBili.Enhanced.Home",
 			"name": "📺 BiliBili: ⚙ Enhanced (首页)",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Home", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -98,14 +98,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Enhanced.Region",
 			"name": "📺 BiliBili: ⚙ Enhanced (分区)",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Region", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -326,14 +326,14 @@
 					"desc": "选择要显示的分区"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Enhanced.Mine",
 			"name": "📺 BiliBili: ⚙ Enhanced (我的) iOS版",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Mine", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -483,14 +483,14 @@
 					"desc": ""
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced/tree/beta",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced/tree/beta",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Enhanced.Mine.iPad",
 			"name": "📺 BiliBili: ⚙ Enhanced (我的) iPad版",
-			"descs_html": ["使用说明请见<a href=\"https://Enhanced.BiliUniverse.io\">🪐 BiliUniverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/enhanced\">🪐 Biliverse: ⚙️ Enhanced</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Enhanced.Settings.Mine.iPad", "@BiliBili.Enhanced.Caches"],
 			"settings": [
 				{
@@ -584,14 +584,14 @@
 					"desc": ""
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced",
-			"icons": ["https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced",
+			"icons": ["https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Enhanced/raw/main/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Global",
 			"name": "📺 BiliBili: 🌐 Global",
-			"descs_html": ["使用说明请见<a href=\"https://Global.BiliUniverse.io\">🪐 BiliUniverse: 🌐 Global</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/global\">🪐 Biliverse: 🌐 Global</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Global.Settings", "@BiliBili.Global.Caches"],
 			"settings": [
 				{
@@ -623,14 +623,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Global",
-			"icons": ["https://github.com/BiliUniverse/Global/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Global/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Global",
+			"icons": ["https://github.com/Biliverse/Global/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Global/raw/main/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.Redirect",
 			"name": "📺 BiliBili: 🔀 Redirect",
-			"descs_html": ["使用说明请见<a href=\"https://Redirect.BiliUniverse.io\">🪐 BiliUniverse: 🔀 Redirect</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/redirect\">🪐 Biliverse: 🔀 Redirect</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.Redirect.Settings", "@BiliBili.Redirect.Caches"],
 			"settings": [
 				{
@@ -688,14 +688,14 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Redirect",
-			"icons": ["https://github.com/BiliUniverse/Redirect/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/Redirect/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Redirect",
+			"icons": ["https://github.com/Biliverse/Redirect/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/Redirect/raw/main/src/assets/icon_circled_108x.png"]
 		},
 		{
 			"id": "BiliBili.ADBlock",
 			"name": "📺 BiliBili: 🛡️ ADBlock",
-			"descs_html": ["使用说明请见<a href=\"https://ADBlock.BiliUniverse.io\">🪐 BiliUniverse: 🛡️ ADBlock</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://biliverse.github.io/guide/ad-block\">🪐 Biliverse: 🛡️ ADBlock</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliBili.ADBlock.Settings", "@BiliBili.ADBlock.Caches"],
 			"settings": [
 				{ "id": "@BiliBili.ADBlock.Settings.Splash", "name": "[开屏] 去除广告", "type": "boolean", "val": true, "desc": "是否启用此处修改" },
@@ -724,9 +724,9 @@
 					"desc": "选择脚本日志的输出等级，低于所选等级的日志将全部输出。"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/ADBlock",
-			"icons": ["https://github.com/BiliUniverse/ADBlock/raw/main/src/assets/icon_circled_108x.png", "https://github.com/BiliUniverse/ADBlock/raw/main/src/assets/icon_circled_108x.png"]
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/ADBlock",
+			"icons": ["https://github.com/Biliverse/ADBlock/raw/main/src/assets/icon_circled_108x.png", "https://github.com/Biliverse/ADBlock/raw/main/src/assets/icon_circled_108x.png"]
 		}
 	]
 }

--- a/BiliIntl.boxjs.beta.json
+++ b/BiliIntl.boxjs.beta.json
@@ -1,15 +1,15 @@
 {
-	"id": "BiliUniverse.BiliIntl.beta.sub",
-	"name": "BiliUniverse: 📺 BiliIntl β",
-	"author": "@BiliUniverse",
+	"id": "Biliverse.BiliIntl.beta.sub",
+	"name": "Biliverse: 📺 BiliIntl β",
+	"author": "@Biliverse",
 	"description": "哔哩哔哩国际版流媒体平台功能增强系列",
 	"icon": "https://avatars.githubusercontent.com/u/129515498?s=200&v=4",
-	"repo": "https://github.com/BiliUniverse/Universe",
+	"repo": "https://github.com/Biliverse/Universe",
 	"apps": [
 		{
 			"id": "BiliIntl.Enhanced.beta",
 			"name": "📺 BiliIntl: Enhanced β",
-			"descs_html": ["使用说明请见<a href=\"https://github.com/BiliUniverse/Universe/wiki\">wiki</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://github.com/Biliverse/Universe/wiki\">wiki</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliIntl.Enhanced.Settings", "@BiliIntl.Enhanced.Caches"],
 			"settings": [
 				{
@@ -91,14 +91,14 @@
 					"desc": "选择启用的底部导航栏，最多6个"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Enhanced/tree/beta",
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Enhanced/tree/beta",
 			"icons": ["https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/bilibili.png", "https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/bilibili.png"]
 		},
 		{
 			"id": "BiliIntl.Global.beta",
 			"name": "📺 BiliIntl: Global β",
-			"descs_html": ["使用说明请见<a href=\"https://github.com/BiliUniverse/Universe/wiki\">wiki</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://github.com/Biliverse/Universe/wiki\">wiki</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliIntl.Global.Settings", "@BiliIntl.Global.Caches"],
 			"settings": [
 				{
@@ -227,14 +227,14 @@
 					"desc": "选择此地区代理或策略组"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Global/tree/beta",
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Global/tree/beta",
 			"icons": ["https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/bilibili.png", "https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/bilibili.png"]
 		},
 		{
 			"id": "BiliIntl.Roaming.beta",
 			"name": "📺 BiliIntl: Roaming β",
-			"descs_html": ["使用说明请见<a href=\"https://github.com/BiliUniverse/Universe/wiki\">wiki</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
+			"descs_html": ["使用说明请见<a href=\"https://github.com/Biliverse/Universe/wiki\">wiki</a>进行配置", "填写完成后记得点击此页面底端右下角的\"保存\"。"],
 			"keys": ["@BiliIntl.Roaming.Settings", "@BiliIntl.Roaming.Caches"],
 			"settings": [
 				{
@@ -345,8 +345,8 @@
 					"desc": "一行一个代理域名，以回车/换行分隔多个域名，留空不修改"
 				}
 			],
-			"author": "@BiliUniverse",
-			"repo": "https://github.com/BiliUniverse/Roaming/tree/beta",
+			"author": "@Biliverse",
+			"repo": "https://github.com/Biliverse/Roaming/tree/beta",
 			"icons": ["https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/bilibili.png", "https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/bilibili.png"]
 		}
 	]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# 🪐 BiliUniverse: 🧰 BoxJs
+# 🪐 Biliverse: 🧰 BoxJs


### PR DESCRIPTION
## Summary

- publish the Biliverse branding update to the beta branch
- synchronize the beta ADBlock settings with the current v0.6.25 generated settings
- retain the beta branch-specific updates while exposing DM.Airborne and the other missing ADBlock options

## Verification

- BiliBili.boxjs.beta.json parses as JSON
- the ADBlock settings array matches ADBlock/template/boxjs.settings.json
- the ADBlock beta app contains 31 settings and DM.Airborne